### PR TITLE
[PoC] tweak the API to work with futures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,7 @@ stm32f100xx = "0.4.0"
 [dependencies.cast]
 default-features = false
 version = "0.2.0"
+
+[dependencies.futures]
+default-features = false
+version = "0.1.13"

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -68,7 +68,7 @@ fn periodic(mut task: Tim7Irq, ref prio: P1, ref thr: T1) {
     let tim7 = TIM7.access(prio, thr);
     let timer = Timer(&tim7);
 
-    if timer.clear_update_flag().is_ok() {
+    if timer.wait().is_ok() {
         let state = STATE.borrow_mut(&mut task);
 
         *state = !*state;

--- a/examples/concurrent.rs
+++ b/examples/concurrent.rs
@@ -1,0 +1,131 @@
+//! Two tasks running concurrently
+
+#![feature(const_fn)]
+#![feature(used)]
+#![no_std]
+
+extern crate cortex_m_rt;
+#[macro_use]
+extern crate cortex_m_rtfm as rtfm;
+extern crate vl;
+
+use rtfm::{Local, P0, P1, T0, T1, TMax};
+use vl::led;
+use vl::serial::Serial;
+use vl::stm32f100xx::interrupt::{Tim7Irq, Usart1Irq};
+use vl::stm32f100xx;
+use vl::timer::Timer;
+
+// CONFIGURATION
+const BAUD_RATE: u32 = 115_200; // bits per second
+const FREQUENCY: u32 = 1; // Hz
+
+// RESOURCES
+peripherals!(stm32f100xx, {
+    AFIO: Peripheral {
+        register_block: Afio,
+        ceiling: C0,
+    },
+    GPIOA: Peripheral {
+        register_block: Gpioa,
+        ceiling: C0,
+    },
+    GPIOC: Peripheral {
+        register_block: Gpioc,
+        ceiling: C0,
+    },
+    RCC: Peripheral {
+        register_block: Rcc,
+        ceiling: C0,
+    },
+    TIM7: Peripheral {
+        register_block: Tim7,
+        ceiling: C1,
+    },
+    USART1: Peripheral {
+        register_block: Usart1,
+        ceiling: C1,
+    },
+});
+
+// INITIALIZATION PHASE
+fn init(ref prio: P0, thr: &TMax) {
+    let afio = AFIO.access(prio, thr);
+    let gpioa = GPIOA.access(prio, thr);
+    let gpioc = GPIOC.access(prio, thr);
+    let rcc = RCC.access(prio, thr);
+    let tim7 = TIM7.access(prio, thr);
+    let usart1 = USART1.access(prio, thr);
+
+    let serial = Serial(&usart1);
+    let timer = Timer(&tim7);
+
+    led::init(&gpioc, &rcc);
+    serial.init(&afio, &gpioa, &rcc, BAUD_RATE);
+    timer.init(&rcc, FREQUENCY);
+    timer.resume();
+}
+
+// IDLE LOOP
+fn idle(_prio: P0, _ceil: T0) -> ! {
+    // Sleep
+    loop {
+        rtfm::wfi();
+    }
+}
+
+// TASKS
+tasks!(stm32f100xx, {
+    led: Task {
+        interrupt: Tim7Irq,
+        priority: P1,
+        enabled: true,
+    },
+    loopback: Task {
+        interrupt: Usart1Irq,
+        priority: P1,
+        enabled: true,
+    },
+});
+
+// Blink an LED
+fn led(mut task: Tim7Irq, ref prio: P1, ref thr: T1) {
+    static STATE: Local<bool, Tim7Irq> = Local::new(false);
+
+    let tim7 = TIM7.access(prio, thr);
+    let timer = Timer(&tim7);
+
+    if timer.wait().is_ok() {
+        let state = STATE.borrow_mut(&mut task);
+
+        *state = !*state;
+
+        if *state {
+            led::BLUE.on();
+        } else {
+            led::BLUE.off();
+        }
+    } else {
+        // Only reachable through `rtfm::request(periodic)`
+        #[cfg(debug_assertions)]
+        unreachable!();
+    }
+}
+// Send back the received byte
+fn loopback(_task: Usart1Irq, ref prio: P1, ref thr: T1) {
+    let usart1 = USART1.access(prio, thr);
+    let serial = Serial(&usart1);
+
+    if let Ok(byte) = serial.read() {
+        if serial.write(byte).is_err() {
+            // As we are echoing the bytes as soon as they arrive, it should
+            // be impossible to have a TX buffer overrun
+            #[cfg(debug_assertions)]
+            unreachable!()
+        }
+    } else {
+        // Only reachable through `rtfm::request(loopback)`
+        #[cfg(debug_assertions)]
+        unreachable!()
+    }
+}

--- a/examples/cooperative.rs
+++ b/examples/cooperative.rs
@@ -1,0 +1,117 @@
+//! Two tasks running cooperatively
+
+#![feature(const_fn)]
+#![feature(used)]
+#![no_std]
+
+extern crate cortex_m_rt;
+#[macro_use]
+extern crate cortex_m_rtfm as rtfm;
+extern crate futures;
+extern crate vl;
+
+use futures::Future;
+use futures::future::{self, Loop};
+use rtfm::{P0, T0, TMax};
+use vl::led;
+use vl::serial::{self, Serial};
+use vl::stm32f100xx;
+use vl::timer::{self, Timer};
+
+// CONFIGURATION
+const BAUD_RATE: u32 = 115_200; // bits per second
+const FREQUENCY: u32 = 1; // Hz
+
+// RESOURCES
+peripherals!(stm32f100xx, {
+    AFIO: Peripheral {
+        register_block: Afio,
+        ceiling: C0,
+    },
+    GPIOA: Peripheral {
+        register_block: Gpioa,
+        ceiling: C0,
+    },
+    GPIOC: Peripheral {
+        register_block: Gpioc,
+        ceiling: C0,
+    },
+    RCC: Peripheral {
+        register_block: Rcc,
+        ceiling: C0,
+    },
+    TIM7: Peripheral {
+        register_block: Tim7,
+        ceiling: C0,
+    },
+    USART1: Peripheral {
+        register_block: Usart1,
+        ceiling: C0,
+    },
+});
+
+// INITIALIZATION PHASE
+fn init(ref prio: P0, thr: &TMax) {
+    let afio = AFIO.access(prio, thr);
+    let gpioa = GPIOA.access(prio, thr);
+    let gpioc = GPIOC.access(prio, thr);
+    let rcc = RCC.access(prio, thr);
+    let tim7 = TIM7.access(prio, thr);
+    let usart1 = USART1.access(prio, thr);
+
+    let serial = Serial(&usart1);
+    let timer = Timer(&tim7);
+
+    led::init(&gpioc, &rcc);
+    serial.init(&afio, &gpioa, &rcc, BAUD_RATE);
+    timer.init(&rcc, FREQUENCY);
+    timer.resume();
+}
+
+// IDLE LOOP
+fn idle(ref prio: P0, ref thr: T0) -> ! {
+    let tim7 = TIM7.access(prio, thr);
+    let usart1 = USART1.access(prio, thr);
+
+    let serial = Serial(&usart1);
+    let timer = Timer(&tim7);
+
+    // Blink an LED
+    let mut led = future::loop_fn::<_, (), _, _>(
+        false, move |mut state| {
+            timer::wait(timer).map(
+                move |_| {
+                    state = !state;
+
+                    if state {
+                        led::BLUE.on();
+                    } else {
+                        led::BLUE.off();
+                    }
+
+                    Loop::Continue(state)
+                }
+            )
+        }
+    );
+
+    // Send back the received byte
+    let mut loopback = future::loop_fn::<_, (), _, _>(
+        (), move |_| {
+            serial::read(serial).and_then(
+                move |byte| {
+                    serial::write(serial, byte).map(Loop::Continue)
+                }
+            )
+        }
+    );
+
+    // Run the tasks cooperatively
+    loop {
+        led.poll().ok();
+        loopback.poll().ok();
+    }
+}
+
+// TASKS
+tasks!(stm32f100xx, {});

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,13 +14,26 @@
 //!
 //! [i]: https://docs.rs/cortex-m-quickstart/0.1.0/cortex_m_quickstart/
 
-#![deny(missing_docs)]
+#![feature(conservative_impl_trait)]
+// #![deny(missing_docs)]
 #![deny(warnings)]
 #![no_std]
 
 pub extern crate stm32f100xx;
 
 extern crate cast;
+extern crate futures;
+
+// From tokio-core
+macro_rules! try_nb {
+    ($e:expr) => {
+        match $e {
+            Ok(t) => t,
+            Err(Error::WouldBlock) => return Ok(Async::NotReady),
+            Err(e) => return Err(e.into()),
+        }
+    }
+}
 
 pub mod led;
 pub mod serial;


### PR DESCRIPTION
Here's the idea I mentioned [a few days ago]: *extend* an IO API (HAL) built on
top of svd2rust generated code to *also* work with futures. The basic gist is
that we preserve the simple signature of the original API (`fn(..) -> Result`),
but add a `WouldBlock` variant to the `Error` enum. Then we can use something
like tokio-core's [`try_nb!`] macro:

[a few days ago]: https://www.reddit.com/r/rust/comments/6a5p9o/eir_fearless_concurrency_in_your_microcontroller/dhbxftk/
[`try_nb!`]: https://docs.rs/tokio-core/0.1.7/tokio_core/macro.try_nb.html

``` rust
macro_rules! try_nb {
    ($e:expr) => {
        match $e {
            Ok(t) => t,
            Err(Error::WouldBlock) => return Ok(Async::NotReady),
            Err(e) => return Err(e.into()),
        }
    }
}
```

To easily turn continuous calls to the original API into futures:

``` rust
pub fn read<'a>(
    serial: Serial<'a>,
) -> impl Future<Item = u8, Error = Error> + 'a {
    future::poll_fn(move || Ok(Async::Ready(try_nb!(serial.read()))))
}
```

These functions that return futures can then be used to write applications that
run tasks cooperatively. See examples/cooperative.rs.

"Q: Couldn't `serial::read` be a method of `Serial`?" Yes, that could be done
in the current implementation because I'm not using traits for the HAL. But that
wouldn't work if I were using traits because `impl Future` is not currently
allowed in trait methods:

``` rust
trait Serial {
    type Error;

    fn read(self) -> Result<u8, Self::Error>;
    fn aread(self) -> impl Future<Item = u8, Error = Self::Error>;
    //~^ compiler error: impl Trait not allowed in trait methods
}
```

cc @etrombly  @thejpster @whitequark

P.S. I'd like to see some application where using cooperative scheduling actually makes sense. The  version of cooperative.rs that uses tasks instead of futures (concurrent.rs) is faster, more efficient (no busy waiting) and has an smaller memory footprint than cooperative.rs