### PR TITLE
adding .cargo/config, dep and usage example

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,9 @@
+[target.thumbv7m-none-eabi]
+runner = 'arm-none-eabi-gdb'
+rustflags = [
+  "-C", "link-arg=-Tlink.x",
+  "-C", "linker=arm-none-eabi-ld",
+  "-Z", "linker-flavor=ld",
+]
+[build]
+target = "thumbv7m-none-eabi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ version = "0.1.0"
 
 [dependencies]
 stm32f100xx = "0.4.0"
+cortex-m = "0.2.10"
+cortex-m-rt = "0.2.4"
+cortex-m-rtfm = "0.1.1"
 
 [dependencies.cast]
 default-features = false

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 > Board Support Crate for the STM32VLDISCOVERY
 
+## Usage example
+
+```
+$ xargo build --example led
+```
+
 # License
 
 Licensed under either of

--- a/Xargo.toml
+++ b/Xargo.toml
@@ -1,0 +1,6 @@
+[dependencies.core]
+
+[dependencies.compiler_builtins]
+features = ["mem"]
+git = "https://github.com/rust-lang-nursery/compiler-builtins"
+stage = 1


### PR DESCRIPTION
I had some troubles in getting this examples to compile and comparing with the cortex-m-quickstart guide I noticed that some files were missing. With this changes I hope future beginners have a smoother quickstart 😛 